### PR TITLE
feat(base): add eslint-plugin-promise with sensible default configuration

### DIFF
--- a/packages/base/index.js
+++ b/packages/base/index.js
@@ -9,6 +9,7 @@ module.exports = {
     ].map(require.resolve),
     plugins: [
         'babel',
+        'promise',
     ],
     rules: {
         'arrow-parens': ['error', 'as-needed', { requireForBlockBody: true }],
@@ -40,13 +41,29 @@ module.exports = {
             {
                 'devDependencies': [
                     '**/*.test.js',
-                ]
-            }
+                ],
+            },
         ],
         'max-len': [
             styleRules['max-len'][0],
             120,
             ...styleRules['max-len'].slice(2),
         ],
-    }
+
+        // Promise plugin
+        'promise/always-return': 'error',
+        'promise/no-return-wrap': 'error',
+        'promise/param-names': 'error',
+        'promise/catch-or-return': 'error',
+        'promise/no-native': 'off',
+        'promise/no-nesting': 'warn',
+        'promise/no-promise-in-callback': 'warn',
+        'promise/no-callback-in-promise': 'warn',
+        'promise/avoid-new': 'off',
+        'promise/no-new-statics': 'error',
+        'promise/no-return-in-finally': 'warn',
+        'promise/valid-params': 'warn',
+        'promise/prefer-await-to-then': 'off',
+        'promise/prefer-await-to-callbacks': 'off',
+    },
 };

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -18,10 +18,12 @@
   },
   "devDependencies": {
     "eslint": "^5.16.0 || ^6.1.0",
-    "eslint-plugin-import": "^2.18.2"
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-promise": "^4.2.1"
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.1.0",
-    "eslint-plugin-import": "^2.18.2"
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-promise": "^4.2.1"
   }
 }


### PR DESCRIPTION
This adds the eslint-plugin-promise dependency with some default configuration based on the reccomended configuration with some changes:

`'promise/avoid-new': 'off'` If there is a reason to create a new Promise there shouldn't be the need to pull in an external library just for that.

`'promise/prefer-await-to-then': 'off'`
`'promise/prefer-await-to-callbacks': 'off'`
These were kept disabled due to an internal poll that favoured no hard rule for async/await preference.