### PR TITLE
fix: disable react prop-types rule for typescript

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -18,11 +18,13 @@
   },
   "devDependencies": {
     "eslint": "^5.16.0 || ^6.1.0 || ^7.0.0",
+    "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-promise": "^4.2.1"
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.1.0 || ^7.0.0",
+    "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-promise": "^4.2.1"
   }

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -15,10 +15,12 @@
   },
   "devDependencies": {
     "eslint": "^5.16.0 || ^6.1.0 || ^7.0.0",
+    "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-import": "^2.18.2"
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.1.0 || ^7.0.0",
+    "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-import": "^2.18.2"
   }
 }

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -16,11 +16,13 @@
   "devDependencies": {
     "eslint": "^5.16.0 || ^6.1.0 || ^7.0.0",
     "eslint-plugin-babel": "^5.3.0",
-    "eslint-plugin-import": "^2.18.2"
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jest": "^23.8.2"
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.1.0 || ^7.0.0",
     "eslint-plugin-babel": "^5.3.0",
-    "eslint-plugin-import": "^2.18.2"
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jest": "^23.8.2"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "eslint": "^5.16.0 || ^6.1.0 || ^7.0.0",
+    "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.14.3",
@@ -26,6 +27,7 @@
   },
   "peerDependencies": {
     "eslint": "^5.16.0 || ^6.1.0 || ^7.0.0",
+    "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.14.3",

--- a/packages/typescript-react/index.js
+++ b/packages/typescript-react/index.js
@@ -33,5 +33,8 @@ module.exports = {
         'react/jsx-filename-extension': ['error', {
             extensions: ['.jsx', '.tsx'],
         }],
+        // Disable prop-types rules, because they are unnecessary when using types
+        'react/prop-types': 'off',
+        'react/require-default-props': 'off',
     }
 };


### PR DESCRIPTION
When using typescript for react projects, its not necessary
to define component prop types, because component props can
be typed natively.